### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/helm_deploy/csr-api/Chart.yaml
+++ b/helm_deploy/csr-api/Chart.yaml
@@ -5,5 +5,5 @@ name: csr-api
 version: 0.2.2
 dependencies:
   - name: generic-service
-    version: 2.8
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

0 allowlist(s) have been detected that can be migrated.


